### PR TITLE
Allow passing arbitrary extra fields when saving a file

### DIFF
--- a/sqlalchemy_file/file.py
+++ b/sqlalchemy_file/file.py
@@ -88,10 +88,7 @@ class File(BaseFile):
         metadata = self.get("metadata", {})
         metadata.update({"filename": self.filename, "content_type": self.content_type})
         stored_file = self.store_content(
-            self.original_content,
-            upload_storage,
-            metadata=metadata,
-            extra=extra
+            self.original_content, upload_storage, metadata=metadata, extra=extra
         )
         self["file_id"] = stored_file.name
         self["upload_storage"] = upload_storage
@@ -106,14 +103,16 @@ class File(BaseFile):
         upload_storage: Optional[str] = None,
         name: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        extra: Optional[Dict[str, str]] = None
+        extra: Optional[Dict[str, str]] = None,
     ) -> StoredFile:
         """Store content into provided `upload_storage`
         with additional `metadata`. Can be use by processors
         to store additional files.
         """
         name = name or str(uuid.uuid4())
-        stored_file = StorageManager.save_file(name, content, upload_storage, metadata, None, extra)
+        stored_file = StorageManager.save_file(
+            name, content, upload_storage, metadata, None, extra
+        )
         self["files"].append("%s/%s" % (upload_storage, name))
         return stored_file
 

--- a/sqlalchemy_file/file.py
+++ b/sqlalchemy_file/file.py
@@ -84,12 +84,14 @@ class File(BaseFile):
 
     def save_to_storage(self, upload_storage: Optional[str] = None) -> None:
         """Save current file into provided `upload_storage`"""
+        extra = self.get("extra", {})
         metadata = self.get("metadata", {})
         metadata.update({"filename": self.filename, "content_type": self.content_type})
         stored_file = self.store_content(
             self.original_content,
             upload_storage,
             metadata=metadata,
+            extra=extra
         )
         self["file_id"] = stored_file.name
         self["upload_storage"] = upload_storage
@@ -104,13 +106,14 @@ class File(BaseFile):
         upload_storage: Optional[str] = None,
         name: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        extra: Optional[Dict[str, str]] = None
     ) -> StoredFile:
         """Store content into provided `upload_storage`
         with additional `metadata`. Can be use by processors
         to store additional files.
         """
         name = name or str(uuid.uuid4())
-        stored_file = StorageManager.save_file(name, content, upload_storage, metadata)
+        stored_file = StorageManager.save_file(name, content, upload_storage, metadata, None, extra)
         self["files"].append("%s/%s" % (upload_storage, name))
         return stored_file
 

--- a/sqlalchemy_file/storage.py
+++ b/sqlalchemy_file/storage.py
@@ -71,7 +71,7 @@ class StorageManager:
         upload_storage: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
-        extra: Optional[Dict[str, str]] = None
+        extra: Optional[Dict[str, Any]] = None,
     ) -> StoredFile:
         """Save file into provided `upload_storage`"""
         container = cls.get(upload_storage)
@@ -96,7 +96,10 @@ class StorageManager:
                 merged_extra["meta_data"] = metadata
             return StoredFile(
                 container.upload_object_via_stream(
-                    iterator=content, object_name=name, extra=merged_extra, headers=headers
+                    iterator=content,
+                    object_name=name,
+                    extra=merged_extra,
+                    headers=headers,
                 )
             )
 

--- a/sqlalchemy_file/storage.py
+++ b/sqlalchemy_file/storage.py
@@ -71,6 +71,7 @@ class StorageManager:
         upload_storage: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
+        extra: Optional[Dict[str, str]] = None
     ) -> StoredFile:
         """Save file into provided `upload_storage`"""
         container = cls.get(upload_storage)
@@ -88,14 +89,14 @@ class StorageManager:
                 )
             return StoredFile(obj)
         else:
-            extra = {}
+            merged_extra = extra.copy() if extra is not None else {}
             if metadata is not None:
                 if "content_type" in metadata:
-                    extra["content_type"] = metadata["content_type"]
-                extra["meta_data"] = metadata
+                    merged_extra["content_type"] = metadata["content_type"]
+                merged_extra["meta_data"] = metadata
             return StoredFile(
                 container.upload_object_via_stream(
-                    iterator=content, object_name=name, extra=extra, headers=headers
+                    iterator=content, object_name=name, extra=merged_extra, headers=headers
                 )
             )
 


### PR DESCRIPTION
This is to support adding extra parameters when uploading files.

The specific use case for this is uploading to S3 with a canned acl.