### PR TITLE
Add option to upload files by path

### DIFF
--- a/sqlalchemy_file/file.py
+++ b/sqlalchemy_file/file.py
@@ -43,9 +43,9 @@ class File(BaseFile):
     def __init__(
         self,
         content: Any = None,
-        content_path: Optional[str] = None,
         filename: Optional[str] = None,
         content_type: Optional[str] = None,
+        content_path: Optional[str] = None,
         **kwargs: Dict[str, Any],
     ) -> None:
         if content is None and content_path is None:
@@ -115,10 +115,10 @@ class File(BaseFile):
         )
         stored_file = self.store_content(
             self.original_content,
-            self.content_path,
             upload_storage,
             extra=extra,
             headers=self.get("headers", None),
+            content_path=self.content_path,
         )
         self["file_id"] = stored_file.name
         self["upload_storage"] = upload_storage
@@ -130,12 +130,12 @@ class File(BaseFile):
     def store_content(
         self,
         content: Any,
-        content_path: Optional[str] = None,
         upload_storage: Optional[str] = None,
         name: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
         extra: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
+        content_path: Optional[str] = None,
     ) -> StoredFile:
         """Store content into provided `upload_storage`
         with additional `metadata`. Can be use by processors
@@ -145,11 +145,11 @@ class File(BaseFile):
         stored_file = StorageManager.save_file(
             name=name,
             content=content,
-            content_path=content_path,
             upload_storage=upload_storage,
             metadata=metadata,
             extra=extra,
             headers=headers,
+            content_path=content_path,
         )
         self["files"].append("{}/{}".format(upload_storage, name))
         return stored_file

--- a/sqlalchemy_file/processors.py
+++ b/sqlalchemy_file/processors.py
@@ -126,7 +126,7 @@ class ThumbnailGenerator(Processor):
         )
         extra.update({"meta_data": metadata})
         stored_file = file.store_content(
-            output, upload_storage, extra=extra, headers=file.get("headers", None)
+            output, upload_storage=upload_storage, extra=extra, headers=file.get("headers", None)
         )
         file.update(
             {

--- a/sqlalchemy_file/storage.py
+++ b/sqlalchemy_file/storage.py
@@ -110,12 +110,11 @@ class StorageManager:
                     file_path=content_path, object_name=name, extra=extra, headers=headers
                 )
             )
-        else:
-            return StoredFile(
-                container.upload_object_via_stream(
-                    iterator=content, object_name=name, extra=extra, headers=headers
-                )
+        return StoredFile(
+            container.upload_object_via_stream(
+                iterator=content, object_name=name, extra=extra, headers=headers
             )
+        )
 
     @classmethod
     def get_file(cls, path: str) -> StoredFile:

--- a/tests/test_single_field.py
+++ b/tests/test_single_field.py
@@ -100,6 +100,16 @@ class TestSingleField:
             assert attachment.content.saved
             assert attachment.content.file.read() == fake_content.encode()
 
+    def test_create_frompath(self, fake_file, fake_content) -> None:
+        with Session(engine) as session:
+            session.add(Attachment(name="Create Fake file", content=File(content_path=fake_file.name)))
+            session.commit()
+            attachment = session.execute(
+                select(Attachment).where(Attachment.name == "Create Fake file")
+            ).scalar_one()
+            assert attachment.content.saved
+            assert attachment.content.file.read() == fake_content.encode()
+
     def test_file_is_created_when_flush(self, fake_file, fake_content) -> None:
         with Session(engine) as session:
             attachment = Attachment(name="Create Fake file 2", content=File(fake_file))


### PR DESCRIPTION
This avoids having to load files into memory. I've been running this in production for some time now without issues, but it's certainly possible that this change breaks some behavior I'm not using, in particular when using positional arguments for `File` constructor. Let me know what you think.