### PR TITLE
Dependency Update: Pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 dependencies = [
     "SQLAlchemy >=1.4, <2.1",
     "apache-libcloud >=3.6, <3.9",
+    "Pillow >=9.4.0, <10.1.0",
 ]
 dynamic = ["version"]
 
@@ -51,7 +52,6 @@ test = [
     "fasteners ==0.19",
     "PyMySQL[rsa] >=1.0.2, <1.2.0",
     "psycopg2-binary >=2.9.5, <3.0.0",
-    "Pillow >=9.4.0, <10.1.0",
     "python-multipart ==0.0.6",
     "fastapi >=0.92, <0.104",
     "Flask >=2.2, <2.3",


### PR DESCRIPTION
Currently, sqlalchemy-file relies on Pillow as an optional dependency in [project.optional-dependencies]. However, from my observations, when users install sqlalchemy-file via poetry, Pillow is not automatically installed, leading to potential DEP002 errors when using ImageValidator.

To improve user experience and avoid such issues, I suggest moving "Pillow >=9.4.0, <10.1.0" from [project.optional-dependencies] to [project.dependencies]. This will allow Pillow to be automatically installed along with sqlalchemy-file.