### PR TITLE
Fix deprecationwarning for datetime.utcnow

### DIFF
--- a/sqlalchemy_file/file.py
+++ b/sqlalchemy_file/file.py
@@ -2,6 +2,7 @@ import os.path
 import uuid
 import warnings
 from datetime import datetime
+from datetime import timezone
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy_file.base import BaseFile
@@ -121,7 +122,7 @@ class File(BaseFile):
         )
         self["file_id"] = stored_file.name
         self["upload_storage"] = upload_storage
-        self["uploaded_at"] = datetime.utcnow().isoformat()
+        self["uploaded_at"] = datetime.now(timezone.utc).isoformat()
         self["path"] = f"{upload_storage}/{stored_file.name}"
         self["url"] = stored_file.get_cdn_url()
         self["saved"] = True


### PR DESCRIPTION
This replaces the call to `datetime.utcnow()` to `datetime.now(timezone.utc)`.
`datetime.utcnow()` is deprecated since python 3.12, and as such shows a warning every time `save_to_storage()` is called.

We use `timezone.utc` instead of the more recent `datetime.utc`, since only the former is available is [python 3.7](https://docs.python.org/3.7/library/datetime.html#datetime.timezone.utc)