### PR TITLE
Expose StoredFile

### DIFF
--- a/sqlalchemy_file/__init__.py
+++ b/sqlalchemy_file/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "0.6.0"
 
 from .file import File as File  # noqa
+from .stored_file import StoredFile as StoredFile  # noqa
 from .types import FileField as FileField  # noqa
 from .types import ImageField as ImageField  # noqa


### PR DESCRIPTION
This exposes the `StoredFile` class to the user.
The main benefit is that it allows users to benefit from completion in their editors, by type-hinting their column as a `Mapped[StoredFile]`.

Example:
```py
file_info: Mapped[sqlalchemy_file.StoredFile] = mapped_column(
    sqlalchemy_file.FileField(upload_storage="files"), nullable=False
)
```

![image](https://github.com/jowilf/sqlalchemy-file/assets/91389613/cccd4026-b753-439a-94a3-19447b78048e)