### PR TITLE
Add support for complex file_id

### DIFF
--- a/sqlalchemy_file/storage.py
+++ b/sqlalchemy_file/storage.py
@@ -127,7 +127,7 @@ class StorageManager:
         The path is expected to be `storage_name/file_id`.
         """
         upload_storage, file_id = cls._get_storage_and_file_id(path)
-        return StoredFile(StorageManager.get(upload_storage).get_object(file_id))
+        return StoredFile(cls.get(upload_storage).get_object(file_id))
 
     @classmethod
     def delete_file(cls, path: str) -> bool:
@@ -136,7 +136,7 @@ class StorageManager:
         The path is expected to be `storage_name/file_id`.
         """
         upload_storage, file_id = cls._get_storage_and_file_id(path)
-        obj = StorageManager.get(upload_storage).get_object(file_id)
+        obj = cls.get(upload_storage).get_object(file_id)
         if obj.driver.name == LOCAL_STORAGE_DRIVER_NAME:
             """Try deleting associated metadata file"""
             with contextlib.suppress(ObjectDoesNotExistError):
@@ -156,5 +156,9 @@ class StorageManager:
 
         The path is expected to be `storage_name/file_id`.
         """
-        path_parts = path.split("/")
-        return "/".join(path_parts[:-1]), path_parts[-1]
+        # first trying complex file_id
+        storage_name, file_id = path.split("/", 1)
+        if storage_name in cls._storages:
+            return storage_name, file_id
+        # the trying complex storage name
+        return tuple(path.rsplit("/", 1))

--- a/tests/test_storage_manager.py
+++ b/tests/test_storage_manager.py
@@ -18,6 +18,18 @@ class TestStorageManager:
             "file",
         )
 
+    def test_get_storage_and_complex_file_id(self) -> None:
+        StorageManager.add_storage("storage", get_dummy_container("storage"))
+
+        assert StorageManager._get_storage_and_file_id("storage/file") == (
+            "storage",
+            "file",
+        )
+        assert StorageManager._get_storage_and_file_id("storage/folder/file") == (
+            "storage",
+            "folder/file",
+        )
+
     def test_first_configured_is_default(self) -> None:
         StorageManager.add_storage("first", get_dummy_container("first"))
         StorageManager.add_storage("second", get_dummy_container("second"))


### PR DESCRIPTION
First of all, many thanks for creating and maintaining this library. It's my first opportunity to contribute to it, so I want to let you know that I appreciate your work.

The changes in this PR are somewhat similar to the logic introduced in https://github.com/jowilf/sqlalchemy-file/pull/149 and https://github.com/jowilf/sqlalchemy-file/pull/154 that adds support for complex store names.

Complex store names are a great feature, but they don't cover cases where content on storage is grouped by any of the arbitrary properties (like `user_id,` `post_id,` or both). This PR adds support for complex file_id, which allows for a more flexible way of organizing files.

Let me know what you think, I'm happy to add more test coverage or update the PR as you see fit.

